### PR TITLE
fix ConcreteCrack benchmark

### DIFF
--- a/PETSc/ConcreteCrack/decal.gem
+++ b/PETSc/ConcreteCrack/decal.gem
@@ -13,7 +13,7 @@ GeoSys-MMP  Material Medium Properties ------------------------------------
   $MAX_POROSITY
     1.0
   $FLAG_COUPLING_HYDROLOGY
-    1    ; 0-not coupled;1=coupled;
+    0    ; 0-not coupled;1=coupled;
   $TEMPERATURE_GEM
     298.15       ; temperature for GEMS in degree Celsius
   $MY_SMART_GEMS


### PR DESCRIPTION
$FLAG_COUPLING_HYDROLOGY is not supported in PETSc version