### PR TITLE
Another correction of TM_axi

### DIFF
--- a/TM/TM_axi.ic
+++ b/TM/TM_axi.ic
@@ -7,5 +7,5 @@ GINA4 - Initial Condition
  $GEO_TYPE
   DOMAIN 
  $DIS_TYPE
-  CONSTANT   25.0
+  CONSTANT   0.0
 #STOP


### PR DESCRIPTION
set the initial temperature of TM to zero because T should be dT in the steady state test. 