### PR TITLE
Modified the input files of THM and H2M_TEP

### DIFF
--- a/TH2M/H2M_TEP/w_exp.msp
+++ b/TH2M/H2M_TEP/w_exp.msp
@@ -20,7 +20,7 @@ GeoSys-MAT-SP: Solid Properties ------------------------------------
     $SWELLING_PRESSURE_TYPE   
       3  0.01 -0.003e-6 0.25 -0.1609 -0.03e-6  0.1e6  
  $BIOT_CONSTANT
-  -1.0    
+  1.0
 $STRESS_INTEGRATION_TOLERANCE
 1.e-9 1.e-8  // f_tol, s_tol
 #STOP
@@ -30,4 +30,4 @@ $STRESS_INTEGRATION_TOLERANCE
         //! 2: \f$ \kappa_{s0}  \f$  
         //! 3: \f$ \alpha_{sp}  \f$  
         //! 4: \f$ \alpha_{ss}  \f$  
-        //! 5: \f$ p_ref        \f$  
+        //! 5: \f$ p_ref        \f$

--- a/TH2M/H2M_TEP/w_exp.pcs
+++ b/TH2M/H2M_TEP/w_exp.pcs
@@ -2,12 +2,13 @@ GeoSys-PCS: Processes ------------------------------------------------
 #PROCESS
  $PCS_TYPE
     MULTI_PHASE_FLOW
-
+ $NEGLECT_H_INI_EFFECT
+ 2
  #PROCESS
  $PCS_TYPE
   DEFORMATION
-  
-
+ $NEGLECT_H_INI_EFFECT
+ 2
 #STOP
 
 GeoSys-PCS: Processes ------------------------------------------------

--- a/THM/thm_decov.pcs
+++ b/THM/thm_decov.pcs
@@ -3,8 +3,8 @@ GeoSys-PCS: Processes ------------------------------------------------
 #PROCESS
  $PCS_TYPE
   RICHARDS_FLOW
- $NUM_TYPE
-   NEW 
+ $NEGLECT_H_INI_EFFECT
+ 2
  $DEACTIVATED_SUBDOMAIN
   1
   2      
@@ -15,8 +15,8 @@ $ELEMENT_MATRIX_OUTPUT
  #PROCESS
  $PCS_TYPE
   HEAT_TRANSPORT   
- $NUM_TYPE
-   NEW   
+ $NEGLECT_H_INI_EFFECT
+ 2
  $DEACTIVATED_SUBDOMAIN
   1
   2 
@@ -26,5 +26,7 @@ $ELEMENT_MATRIX_OUTPUT
    DEFORMATION    
   $RELOAD          
    2 
+ $NEGLECT_H_INI_EFFECT
+ 2
 #STOP
 


### PR DESCRIPTION
THM : added NEGLECT_H_INI_EFFECT (2) to process definition in order to recovery the original set-up of this benchmark.
H2M_TEP: the same as that for THM, added NEGLECT_H_INI_EFFECT (2) to process definition. Besides, made the Biot's constant positive (see item 1 in the description of PR ufz/ogs5#105).